### PR TITLE
Add Sass support and light container/components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This change log adheres to standards from [Keep a CHANGELOG].
 [Semantic Versioning]: http://semver.org/
 [Keep a CHANGELOG]: http://keepachangelog.com
 
-## [Unreleased]
+## [1.2.0] 2021-05-31
 
 #### :rocket: Enhancement
 * Add `--light` command option to `create-component` to create components with
@@ -30,6 +30,7 @@ for importing modules without using relative paths.
 
 :rocket: Woohoo! The First release!
 
+[1.2.0]: https://github.com/erremauro/cra-template-rear/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/erremauro/cra-template-rear/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/erremauro/cra-template-rear/releases/tag/v1.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ This change log adheres to standards from [Keep a CHANGELOG].
 [Semantic Versioning]: http://semver.org/
 [Keep a CHANGELOG]: http://keepachangelog.com
 
+## [Unreleased]
+
+#### :rocket: Enhancement
+* Add `--light` command option to `create-component` to create components with
+no inner implementation.
+* Add `--light` command option to `create-container` to create containers with
+no action providers.
+* Add support for configuring Sass or CSS stylesheet format.
+
 ## [1.1.0] 2021-05-31
 
 #### :rocket: Enhancement

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Opinionated [create-react-app](https://github.com/facebookincubator/create-react
   - [Creating a new component](#creating-a-new-component)
   - [Creating a new container](#creating-a-new-container)
   - [Creating actions](#creating-actions)
+- [Using SASS](#using-sass)
 - [API Middleware](#api-middleware)
 
 ## Installation
@@ -122,6 +123,27 @@ Create a new set of actions and a reducer in `./src/actions` and `./reducers`
 
 Once the reducer has been created it must be manually added to 
 `./src/reducers/index.js` reducers list.
+
+## Using SASS
+
+You can configure your project for using [Sass](https://sass-lang.com) or CSS
+stylesheet format in `package.json`'s `rearConfig` section by changing the
+`sass` property.
+
+```json
+{
+  "rearConfig": {
+    "sass": true
+  }
+}
+```
+
+You can then run `yarn setup` to reconfigure your project. 
+
+**Note**: During the configuration process the stylesheets are just renamed. No
+changes to the content is made. Bear in mind that if you choose to downgrade
+to CSS from Sass, you'll need to update the content that uses Sass specifc
+syntax. 
 
 ## API Middleware
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cra-template-rear",
   "description": "React template bundled with react-redux and react-router",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "author": "Roberto Mauro <erremauro@icloud.com>",
   "engines": {
     "node": ">= 12.0.0"
@@ -61,6 +61,9 @@
     "create-action": "./scripts/create-action.js",
     "create-container": "./scripts/create-container.js",
     "create-component": "./scripts/create-component.js"
+  },
+  "rearConfig": {
+    "sass": false
   },
   "eslintConfig": {
     "extends": [

--- a/scripts/create-component.js
+++ b/scripts/create-component.js
@@ -4,12 +4,14 @@ const humps = require('humps');
 const logger = require('rear-logger')('create-component');
 const checkDir = require('./lib/check-dir');
 const isPath = require('./lib/is-path');
+const parseArgs = require('./lib/parse-args');
 const createTemplates = require('./lib/create-templates');
+const styleExt = require('./lib/style-extension');
 
 const COMPONENT_TEMPLATE = `
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
-import './$1.css';
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import "./$1.${styleExt}";
 
 class $1 extends Component {
   static propTypes = {
@@ -31,8 +33,19 @@ class $1 extends Component {
 export default $1;
 `;
 
+const COMPONENT_TEMPLATE_LIGHT = `
+import React from "react";
+import "./$1.${styleExt}";
+
+const $1 = (props) =>
+  <div className="$1">
+  </div>
+
+export default $1;
+`;
+
 const INDEX_TEMPLATE = `
-export { default } from './$1';
+export { default } from "./$1";
 `
 const CSS_TEMPLATE = `
 .$1 {
@@ -46,7 +59,11 @@ if (require.main === module) {
   Main(process.argv.slice(2));
 }
 
-function Main(args) {
+function Main(argv) {
+  const program = parseArgs(argv);
+  const { isLight } = program.options;
+  const { args } = program;
+
   const componentsPath = isPath(args[0])
     ? args.shift(0, 1)
     : path.resolve(__dirname, '..', 'src', 'components');
@@ -57,11 +74,13 @@ function Main(args) {
 
   if (!checkDir(componentDir)) return;
 
+  const TEMPLATE = isLight ? COMPONENT_TEMPLATE_LIGHT : COMPONENT_TEMPLATE;
+
   createTemplates([{
     file: path.join(componentDir, `${componentName}.js`),
-    data: COMPONENT_TEMPLATE.replace(PATTERN, componentName).trim()
+    data: TEMPLATE.replace(PATTERN, componentName).trim()
   }, {
-    file: path.join(componentDir, `${componentName}.css`),
+    file: path.join(componentDir, `${componentName}.${styleExt}`),
     data: CSS_TEMPLATE.replace(PATTERN, componentName).trim()
   }, {
     file: path.join(componentDir, 'index.js'),
@@ -69,4 +88,14 @@ function Main(args) {
   }]);
 
   logger.log();
+}
+
+function isLightComponent(args) {
+  const optionId = args.findIndex(arg => /^(--light|-l)/i.test(arg));
+  let isLight = false;
+  if (optionId !== -1) {
+    isLight = true;
+    args.splice(optionId, 1);
+  }
+  return isLight;
 }

--- a/scripts/create-container.js
+++ b/scripts/create-container.js
@@ -4,13 +4,15 @@ const humps = require('humps');
 const logger = require('rear-logger')('create-container');
 const checkDir = require('./lib/check-dir');
 const isPath = require('./lib/is-path');
+const parseArgs = require('./lib/parse-args');
 const createTemplates = require('./lib/create-templates');
+const styleExt = require('./lib/style-extension');
 
 const CONTAINER_TEMPLATE = `
-import React, { Component } from 'react';
-import { connect } from 'react-redux';
-import { getProps, getActions } from './Providers';
-import './$1.css';
+import React, { Component } from "react";
+import { connect } from "react-redux";
+import { getProps, getActions } from "./Providers";
+import "./$1.${styleExt}";
 
 class $1 extends Component {
 	render() {
@@ -24,8 +26,24 @@ class $1 extends Component {
 export default connect(getProps, getActions)($1);
 `;
 
+const CONTAINER_TEMPLATE_LIGHT = `
+import React, { Component } from "react";
+import "./$1.${styleExt}";
+
+class $1 extends Component {
+  render() {
+    return(
+      <div className="$1">
+      </div>
+    );
+  }
+}
+
+export default $1;
+`;
+
 const INDEX_TEMPLATE = `
-export { default } from './$1';
+export { default } from "./$1";
 `
 const CSS_TEMPLATE = `
 .$1 {
@@ -34,7 +52,7 @@ const CSS_TEMPLATE = `
 `;
 
 const PROVIDER_TEMPLATE = `
-// import { myAction } from '../../actions/MyActions';
+// import { myAction } from "../../actions/MyActions";
 
 export function getActions(dispatch) {
   return {
@@ -57,7 +75,11 @@ if (require.main === module) {
 
 /////////////////////////////////
 
-function Main(args) {
+function Main(argv) {
+  const program = parseArgs(argv);
+  const { isLight } = program.options;
+  const { args } = program;
+
   const containersPath = isPath(args[0])
     ? args.shift(0, 1)
     : path.resolve(__dirname, '..', 'src', 'containers');
@@ -68,11 +90,13 @@ function Main(args) {
 
   if (!checkDir(containerDir)) return;
 
-  createTemplates([{
+  const TEMPLATE = isLight ? CONTAINER_TEMPLATE_LIGHT : CONTAINER_TEMPLATE;
+
+  const files = [{
     file: path.join(containerDir, `${containerName}.js`),
-    data: CONTAINER_TEMPLATE.replace(PATTERN, containerName)
+    data: TEMPLATE.replace(PATTERN, containerName)
   }, {
-    file: path.join(containerDir, `${containerName}.css`),
+    file: path.join(containerDir, `${containerName}.${styleExt}`),
     data: CSS_TEMPLATE.replace(PATTERN, containerName)
   }, {
     file: path.join(containerDir, `Providers.js`),
@@ -80,7 +104,12 @@ function Main(args) {
   }, {
     file: path.join(containerDir, 'index.js'),
     data: INDEX_TEMPLATE.replace(PATTERN, containerName)
-  }]);
+  }];
+
+  // removes provider template
+  if (isLight) files.splice(2, 1);
+
+  createTemplates(files);
 
   logger.log();
 }

--- a/scripts/lib/parse-args.js
+++ b/scripts/lib/parse-args.js
@@ -1,0 +1,22 @@
+module.exports = parseArgs;
+
+///////////////////////////////////////////
+
+function parseArgs(argv) {
+  let isLight = false;
+
+  const args = argv;
+  const isLightId = args.findIndex((arg) => /^(--light|-l)/i.test(arg));
+
+  if (isLightId !== -1) {
+    isLight = true;
+    args.splice(isLightId, 1);
+  }
+
+  return {
+    args,
+    options: {
+      isLight,
+    },
+  };
+}

--- a/scripts/lib/style-extension.js
+++ b/scripts/lib/style-extension.js
@@ -1,0 +1,8 @@
+const pkg = require("../../package.json");
+
+let styleExt = "css";
+if (pkg.rearConfig) {
+  styleExt = pkg.rearConfig.sass ? "scss" : "css";
+}
+
+module.exports = styleExt;

--- a/scripts/lib/walk.js
+++ b/scripts/lib/walk.js
@@ -1,0 +1,29 @@
+const fs = require("fs");
+
+module.exports = walk;
+
+///////////////////////////////////////////
+
+function walk(dir, done) {
+  let results = [];
+  fs.readdir(dir, function (err, list) {
+    if (err) return done(err);
+    let i = 0;
+    (function next() {
+      let file = list[i++];
+      if (!file) return done(null, results);
+      file = dir + "/" + file;
+      fs.stat(file, function (err, stat) {
+        if (stat && stat.isDirectory()) {
+          walk(file, function (err, res) {
+            results = results.concat(res);
+            next();
+          });
+        } else {
+          results.push(file);
+          next();
+        }
+      });
+    })();
+  });
+}

--- a/scripts/setup/configure-styles.js
+++ b/scripts/setup/configure-styles.js
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+const fs = require("fs");
+const path = require("path");
+const walk = require("../lib/walk");
+const styleExt = require("../lib/style-extension");
+const { spawnSync } = require("child_process");
+const pkg = require("../../package.json");
+
+if (require.main === module) {
+  configureStyles(process.argv.slice(2)).catch((err) => {
+    console.error(err);
+  });
+} else {
+  module.exports = configureStyles;
+}
+
+///////////////////////////////////////////
+
+function configureStyles() {
+  return new Promise((resolve, reject) => {
+    const isSass = styleExt === "scss";
+    const hasSass = pkg.dependencies["sass"];
+
+    if (isSass && !hasSass) {
+      spawnSync(
+        "yarn",
+        ["add", "sass", "--cwd", path.resolve(__dirname + "../../")],
+        { stdio: "inherit" }
+      );
+    } else if (!isSass && hasSass) {
+      spawnSync(
+        "yarn",
+        ["remove", "sass", "--cwd", path.resolve(__dirname + "../../")],
+        { stdio: "inherit" }
+      );
+    }
+
+    walk(path.resolve(__dirname + "/../../src"), (err, results) => {
+      if (err) throw err;
+
+      const styleExtPattern = isSass ? /\.css$/i : /\.scss$/i;
+      const jsStylePattern = isSass ? /\w+(\.css)/g : /\w+(\.scss)/g;
+      const newStyleExt = isSass ? ".scss" : ".css";
+      const oldStyleExt = isSass ? ".css" : ".scss";
+
+      const promises = results.map(
+        (file) =>
+          new Promise((resolve, reject) => {
+            const extname = path.extname(file);
+
+            // Rename stylesheets
+            if (extname === oldStyleExt) {
+              const newName = file.replace(styleExtPattern, newStyleExt);
+              fs.rename(file, newName, (err) => {
+                if (err) return reject(err);
+              });
+            } else {
+              resolve();
+            }
+
+            // Replace stylesheet references inside files
+            if (extname === ".js") {
+              fs.readFile(file, "utf-8", (err, data) => {
+                const matches = data.match(jsStylePattern);
+                let replacements = [];
+                if (matches !== null) {
+                  replacements = matches.map((m) =>
+                    m.replace(oldStyleExt, newStyleExt)
+                  );
+
+                  matches.forEach((m, i) => {
+                    data = data.replace(m, replacements[i]);
+                  });
+
+                  fs.writeFile(file, data, () => {
+                    if (err) return reject(err);
+                    resolve();
+                  });
+                }
+              });
+            }
+          })
+      );
+
+      return Promise.all(promises);
+    });
+  });
+}

--- a/scripts/setup/configure-styles.js
+++ b/scripts/setup/configure-styles.js
@@ -21,22 +21,25 @@ function configureStyles() {
     const isSass = styleExt === "scss";
     const hasSass = pkg.dependencies["sass"];
 
+    const sassCwd = path.resolve(path.join(__dirname, "..", ".."));
+    const walkDir = path.resolve(path.join(sassCwd, "src"));
+
     if (isSass && !hasSass) {
       spawnSync(
         "yarn",
-        ["add", "sass", "--cwd", path.resolve(__dirname + "../../")],
+        ["add", "sass", "--cwd", sassCwd],
         { stdio: "inherit" }
       );
     } else if (!isSass && hasSass) {
       spawnSync(
         "yarn",
-        ["remove", "sass", "--cwd", path.resolve(__dirname + "../../")],
+        ["remove", "sass", "--cwd", sassCwd],
         { stdio: "inherit" }
       );
     }
 
-    walk(path.resolve(__dirname + "/../../src"), (err, results) => {
-      if (err) throw err;
+    walk(walkDir, (err, results) => {
+      if (err) return reject(err);
 
       const styleExtPattern = isSass ? /\.css$/i : /\.scss$/i;
       const jsStylePattern = isSass ? /\w+(\.css)/g : /\w+(\.scss)/g;
@@ -60,7 +63,7 @@ function configureStyles() {
 
             // Replace stylesheet references inside files
             if (extname === ".js") {
-              fs.readFile(file, "utf-8", (err, data) => {
+              fs.readFile(file, "utf-8", (err, data) => {                
                 const matches = data.match(jsStylePattern);
                 let replacements = [];
                 if (matches !== null) {
@@ -82,7 +85,7 @@ function configureStyles() {
           })
       );
 
-      return Promise.all(promises);
+      return Promise.all(promises).then(() => resolve());
     });
   });
 }

--- a/scripts/setup/configure-styles.js
+++ b/scripts/setup/configure-styles.js
@@ -56,31 +56,30 @@ function configureStyles() {
               const newName = file.replace(styleExtPattern, newStyleExt);
               fs.rename(file, newName, (err) => {
                 if (err) return reject(err);
+                return resolve();
               });
-            } else {
-              resolve();
             }
-
-            // Replace stylesheet references inside files
-            if (extname === ".js") {
+            else if (extname === ".js") {
               fs.readFile(file, "utf-8", (err, data) => {                
                 const matches = data.match(jsStylePattern);
                 let replacements = [];
-                if (matches !== null) {
-                  replacements = matches.map((m) =>
-                    m.replace(oldStyleExt, newStyleExt)
-                  );
+                if (matches === null) return resolve()
 
-                  matches.forEach((m, i) => {
-                    data = data.replace(m, replacements[i]);
-                  });
+                replacements = matches.map((m) =>
+                  m.replace(oldStyleExt, newStyleExt)
+                );
 
-                  fs.writeFile(file, data, () => {
-                    if (err) return reject(err);
-                    resolve();
-                  });
-                }
+                matches.forEach((m, i) => {
+                  data = data.replace(m, replacements[i]);
+                });
+
+                fs.writeFile(file, data, () => {
+                  if (err) return reject(err);
+                  resolve();
+                });
               });
+            } else {
+              return resolve();
             }
           })
       );

--- a/scripts/setup/pre-install.js
+++ b/scripts/setup/pre-install.js
@@ -16,6 +16,8 @@ function preInstall() {
   try {
     fs.unlinkSync(targetPath);  
   } catch (err) {
-    // no output
+    if (err.code !== "ENOENT") {
+      throw err;
+    }
   }
 }

--- a/scripts/setup/setup.js
+++ b/scripts/setup/setup.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
-const preInstall = require('./pre-install')
-const postInstall = require('./post-install')
+const preInstall = require("./pre-install");
+const postInstall = require("./post-install");
+const configureStyles = require("./configure-styles");
 
 if (require.main === module) {
   setup();
@@ -13,4 +14,5 @@ if (require.main === module) {
 function setup() {
   preInstall();
   postInstall();
+  configureStyles();
 }

--- a/scripts/setup/setup.js
+++ b/scripts/setup/setup.js
@@ -2,6 +2,7 @@
 const preInstall = require("./pre-install");
 const postInstall = require("./post-install");
 const configureStyles = require("./configure-styles");
+const logger = require("rear-logger")("setup");
 
 if (require.main === module) {
   setup();
@@ -12,7 +13,18 @@ if (require.main === module) {
 ///////////////////////////////////////////
 
 function setup() {
+  logger.log("Setting up your project... \n");
+  logger.info("Removing %cnode_modules/@", "cyan");
   preInstall();
-  postInstall();
-  configureStyles();
+  
+  logger.info("Configuring styles...");
+  configureStyles().then(() => {
+    logger.info(
+      "Symlinking %csrc%c to %cnode_modules/@\n",
+      "green",
+      "reset",
+      "cyan"
+    );
+    postInstall();
+  });
 }

--- a/template.json
+++ b/template.json
@@ -38,6 +38,6 @@
     },
     "rearConfig": {
       "sass": false
-    },
+    }
   }
 }

--- a/template.json
+++ b/template.json
@@ -35,6 +35,9 @@
         "react-app",
         "react-app/jest"
       ]
-    }
+    },
+    "rearConfig": {
+      "sass": false
+    },
   }
 }

--- a/template/README.md
+++ b/template/README.md
@@ -21,6 +21,7 @@ Opinionated [create-react-app](https://github.com/facebookincubator/create-react
   - [Creating a new component](#creating-a-new-component)
   - [Creating a new container](#creating-a-new-container)
   - [Creating actions](#creating-actions)
+- [Using SASS](#using-sass)
 - [API Middleware](#api-middleware)
 
 ## Installation
@@ -122,6 +123,27 @@ Create a new set of actions and a reducer in `./src/actions` and `./reducers`
 
 Once the reducer has been created it must be manually added to 
 `./src/reducers/index.js` reducers list.
+
+## Using SASS
+
+You can configure your project for using [Sass](https://sass-lang.com) or CSS
+stylesheet format in `package.json`'s `rearConfig` section by changing the
+`sass` property.
+
+```json
+{
+  "rearConfig": {
+    "sass": true
+  }
+}
+```
+
+You can then run `yarn setup` to reconfigure your project. 
+
+**Note**: During the configuration process the stylesheets are just renamed. No
+changes to the content is made. Bear in mind that if you choose to downgrade
+to CSS from Sass, you'll need to update the content that uses Sass specifc
+syntax. 
 
 ## API Middleware
 

--- a/template/scripts/create-component.js
+++ b/template/scripts/create-component.js
@@ -4,12 +4,14 @@ const humps = require('humps');
 const logger = require('rear-logger')('create-component');
 const checkDir = require('./lib/check-dir');
 const isPath = require('./lib/is-path');
+const parseArgs = require('./lib/parse-args');
 const createTemplates = require('./lib/create-templates');
+const styleExt = require('./lib/style-extension');
 
 const COMPONENT_TEMPLATE = `
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
-import './$1.css';
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import "./$1.${styleExt}";
 
 class $1 extends Component {
   static propTypes = {
@@ -31,8 +33,19 @@ class $1 extends Component {
 export default $1;
 `;
 
+const COMPONENT_TEMPLATE_LIGHT = `
+import React from "react";
+import "./$1.${styleExt}";
+
+const $1 = (props) =>
+  <div className="$1">
+  </div>
+
+export default $1;
+`;
+
 const INDEX_TEMPLATE = `
-export { default } from './$1';
+export { default } from "./$1";
 `
 const CSS_TEMPLATE = `
 .$1 {
@@ -46,7 +59,11 @@ if (require.main === module) {
   Main(process.argv.slice(2));
 }
 
-function Main(args) {
+function Main(argv) {
+  const program = parseArgs(argv);
+  const { isLight } = program.options;
+  const { args } = program;
+
   const componentsPath = isPath(args[0])
     ? args.shift(0, 1)
     : path.resolve(__dirname, '..', 'src', 'components');
@@ -57,11 +74,13 @@ function Main(args) {
 
   if (!checkDir(componentDir)) return;
 
+  const TEMPLATE = isLight ? COMPONENT_TEMPLATE_LIGHT : COMPONENT_TEMPLATE;
+
   createTemplates([{
     file: path.join(componentDir, `${componentName}.js`),
-    data: COMPONENT_TEMPLATE.replace(PATTERN, componentName).trim()
+    data: TEMPLATE.replace(PATTERN, componentName).trim()
   }, {
-    file: path.join(componentDir, `${componentName}.css`),
+    file: path.join(componentDir, `${componentName}.${styleExt}`),
     data: CSS_TEMPLATE.replace(PATTERN, componentName).trim()
   }, {
     file: path.join(componentDir, 'index.js'),
@@ -69,4 +88,14 @@ function Main(args) {
   }]);
 
   logger.log();
+}
+
+function isLightComponent(args) {
+  const optionId = args.findIndex(arg => /^(--light|-l)/i.test(arg));
+  let isLight = false;
+  if (optionId !== -1) {
+    isLight = true;
+    args.splice(optionId, 1);
+  }
+  return isLight;
 }

--- a/template/scripts/create-container.js
+++ b/template/scripts/create-container.js
@@ -4,13 +4,15 @@ const humps = require('humps');
 const logger = require('rear-logger')('create-container');
 const checkDir = require('./lib/check-dir');
 const isPath = require('./lib/is-path');
+const parseArgs = require('./lib/parse-args');
 const createTemplates = require('./lib/create-templates');
+const styleExt = require('./lib/style-extension');
 
 const CONTAINER_TEMPLATE = `
-import React, { Component } from 'react';
-import { connect } from 'react-redux';
-import { getProps, getActions } from './Providers';
-import './$1.css';
+import React, { Component } from "react";
+import { connect } from "react-redux";
+import { getProps, getActions } from "./Providers";
+import "./$1.${styleExt}";
 
 class $1 extends Component {
 	render() {
@@ -24,8 +26,24 @@ class $1 extends Component {
 export default connect(getProps, getActions)($1);
 `;
 
+const CONTAINER_TEMPLATE_LIGHT = `
+import React, { Component } from "react";
+import "./$1.${styleExt}";
+
+class $1 extends Component {
+  render() {
+    return(
+      <div className="$1">
+      </div>
+    );
+  }
+}
+
+export default $1;
+`;
+
 const INDEX_TEMPLATE = `
-export { default } from './$1';
+export { default } from "./$1";
 `
 const CSS_TEMPLATE = `
 .$1 {
@@ -34,7 +52,7 @@ const CSS_TEMPLATE = `
 `;
 
 const PROVIDER_TEMPLATE = `
-// import { myAction } from '../../actions/MyActions';
+// import { myAction } from "../../actions/MyActions";
 
 export function getActions(dispatch) {
   return {
@@ -57,7 +75,11 @@ if (require.main === module) {
 
 /////////////////////////////////
 
-function Main(args) {
+function Main(argv) {
+  const program = parseArgs(argv);
+  const { isLight } = program.options;
+  const { args } = program;
+
   const containersPath = isPath(args[0])
     ? args.shift(0, 1)
     : path.resolve(__dirname, '..', 'src', 'containers');
@@ -68,11 +90,13 @@ function Main(args) {
 
   if (!checkDir(containerDir)) return;
 
-  createTemplates([{
+  const TEMPLATE = isLight ? CONTAINER_TEMPLATE_LIGHT : CONTAINER_TEMPLATE;
+
+  const files = [{
     file: path.join(containerDir, `${containerName}.js`),
-    data: CONTAINER_TEMPLATE.replace(PATTERN, containerName)
+    data: TEMPLATE.replace(PATTERN, containerName)
   }, {
-    file: path.join(containerDir, `${containerName}.css`),
+    file: path.join(containerDir, `${containerName}.${styleExt}`),
     data: CSS_TEMPLATE.replace(PATTERN, containerName)
   }, {
     file: path.join(containerDir, `Providers.js`),
@@ -80,7 +104,12 @@ function Main(args) {
   }, {
     file: path.join(containerDir, 'index.js'),
     data: INDEX_TEMPLATE.replace(PATTERN, containerName)
-  }]);
+  }];
+
+  // removes provider template
+  if (isLight) files.splice(2, 1);
+
+  createTemplates(files);
 
   logger.log();
 }

--- a/template/scripts/lib/parse-args.js
+++ b/template/scripts/lib/parse-args.js
@@ -1,0 +1,22 @@
+module.exports = parseArgs;
+
+///////////////////////////////////////////
+
+function parseArgs(argv) {
+  let isLight = false;
+
+  const args = argv;
+  const isLightId = args.findIndex((arg) => /^(--light|-l)/i.test(arg));
+
+  if (isLightId !== -1) {
+    isLight = true;
+    args.splice(isLightId, 1);
+  }
+
+  return {
+    args,
+    options: {
+      isLight,
+    },
+  };
+}

--- a/template/scripts/lib/style-extension.js
+++ b/template/scripts/lib/style-extension.js
@@ -1,0 +1,8 @@
+const pkg = require("../../package.json");
+
+let styleExt = "css";
+if (pkg.rearConfig) {
+  styleExt = pkg.rearConfig.sass ? "scss" : "css";
+}
+
+module.exports = styleExt;

--- a/template/scripts/lib/walk.js
+++ b/template/scripts/lib/walk.js
@@ -1,0 +1,29 @@
+const fs = require("fs");
+
+module.exports = walk;
+
+///////////////////////////////////////////
+
+function walk(dir, done) {
+  let results = [];
+  fs.readdir(dir, function (err, list) {
+    if (err) return done(err);
+    let i = 0;
+    (function next() {
+      let file = list[i++];
+      if (!file) return done(null, results);
+      file = dir + "/" + file;
+      fs.stat(file, function (err, stat) {
+        if (stat && stat.isDirectory()) {
+          walk(file, function (err, res) {
+            results = results.concat(res);
+            next();
+          });
+        } else {
+          results.push(file);
+          next();
+        }
+      });
+    })();
+  });
+}

--- a/template/scripts/setup/configure-styles.js
+++ b/template/scripts/setup/configure-styles.js
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+const fs = require("fs");
+const path = require("path");
+const walk = require("../lib/walk");
+const styleExt = require("../lib/style-extension");
+const { spawnSync } = require("child_process");
+const pkg = require("../../package.json");
+
+if (require.main === module) {
+  configureStyles(process.argv.slice(2)).catch((err) => {
+    console.error(err);
+  });
+} else {
+  module.exports = configureStyles;
+}
+
+///////////////////////////////////////////
+
+function configureStyles() {
+  return new Promise((resolve, reject) => {
+    const isSass = styleExt === "scss";
+    const hasSass = pkg.dependencies["sass"];
+
+    if (isSass && !hasSass) {
+      spawnSync(
+        "yarn",
+        ["add", "sass", "--cwd", path.resolve(__dirname + "../../")],
+        { stdio: "inherit" }
+      );
+    } else if (!isSass && hasSass) {
+      spawnSync(
+        "yarn",
+        ["remove", "sass", "--cwd", path.resolve(__dirname + "../../")],
+        { stdio: "inherit" }
+      );
+    }
+
+    walk(path.resolve(__dirname + "/../../src"), (err, results) => {
+      if (err) throw err;
+
+      const styleExtPattern = isSass ? /\.css$/i : /\.scss$/i;
+      const jsStylePattern = isSass ? /\w+(\.css)/g : /\w+(\.scss)/g;
+      const newStyleExt = isSass ? ".scss" : ".css";
+      const oldStyleExt = isSass ? ".css" : ".scss";
+
+      const promises = results.map(
+        (file) =>
+          new Promise((resolve, reject) => {
+            const extname = path.extname(file);
+
+            // Rename stylesheets
+            if (extname === oldStyleExt) {
+              const newName = file.replace(styleExtPattern, newStyleExt);
+              fs.rename(file, newName, (err) => {
+                if (err) return reject(err);
+              });
+            } else {
+              resolve();
+            }
+
+            // Replace stylesheet references inside files
+            if (extname === ".js") {
+              fs.readFile(file, "utf-8", (err, data) => {
+                const matches = data.match(jsStylePattern);
+                let replacements = [];
+                if (matches !== null) {
+                  replacements = matches.map((m) =>
+                    m.replace(oldStyleExt, newStyleExt)
+                  );
+
+                  matches.forEach((m, i) => {
+                    data = data.replace(m, replacements[i]);
+                  });
+
+                  fs.writeFile(file, data, () => {
+                    if (err) return reject(err);
+                    resolve();
+                  });
+                }
+              });
+            }
+          })
+      );
+
+      return Promise.all(promises);
+    });
+  });
+}

--- a/template/scripts/setup/configure-styles.js
+++ b/template/scripts/setup/configure-styles.js
@@ -21,22 +21,25 @@ function configureStyles() {
     const isSass = styleExt === "scss";
     const hasSass = pkg.dependencies["sass"];
 
+    const sassCwd = path.resolve(path.join(__dirname, "..", ".."));
+    const walkDir = path.resolve(path.join(sassCwd, "src"));
+
     if (isSass && !hasSass) {
       spawnSync(
         "yarn",
-        ["add", "sass", "--cwd", path.resolve(__dirname + "../../")],
+        ["add", "sass", "--cwd", sassCwd],
         { stdio: "inherit" }
       );
     } else if (!isSass && hasSass) {
       spawnSync(
         "yarn",
-        ["remove", "sass", "--cwd", path.resolve(__dirname + "../../")],
+        ["remove", "sass", "--cwd", sassCwd],
         { stdio: "inherit" }
       );
     }
 
-    walk(path.resolve(__dirname + "/../../src"), (err, results) => {
-      if (err) throw err;
+    walk(walkDir, (err, results) => {
+      if (err) return reject(err);
 
       const styleExtPattern = isSass ? /\.css$/i : /\.scss$/i;
       const jsStylePattern = isSass ? /\w+(\.css)/g : /\w+(\.scss)/g;
@@ -60,29 +63,33 @@ function configureStyles() {
 
             // Replace stylesheet references inside files
             if (extname === ".js") {
-              fs.readFile(file, "utf-8", (err, data) => {
+              fs.readFile(file, "utf-8", (err, data) => {                
                 const matches = data.match(jsStylePattern);
                 let replacements = [];
-                if (matches !== null) {
-                  replacements = matches.map((m) =>
-                    m.replace(oldStyleExt, newStyleExt)
-                  );
+                if (matches === null) return resolve()
 
-                  matches.forEach((m, i) => {
-                    data = data.replace(m, replacements[i]);
-                  });
+                replacements = matches.map((m) =>
+                  m.replace(oldStyleExt, newStyleExt)
+                );
 
-                  fs.writeFile(file, data, () => {
-                    if (err) return reject(err);
-                    resolve();
-                  });
-                }
+                matches.forEach((m, i) => {
+                  data = data.replace(m, replacements[i]);
+                });
+
+                fs.writeFile(file, data, () => {
+                  if (err) return reject(err);
+                  resolve();
+                });
               });
+            }
+
+            if (extname !== '.js' && extname !== oldStyleExt) {
+              return resolve();
             }
           })
       );
 
-      return Promise.all(promises);
+      return Promise.all(promises).then(() => resolve());
     });
   });
 }

--- a/template/scripts/setup/pre-install.js
+++ b/template/scripts/setup/pre-install.js
@@ -16,6 +16,8 @@ function preInstall() {
   try {
     fs.unlinkSync(targetPath);  
   } catch (err) {
-    // no output
+    if (err.code !== "ENOENT") {
+      throw err;
+    }
   }
 }

--- a/template/scripts/setup/setup.js
+++ b/template/scripts/setup/setup.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
-const preInstall = require('./pre-install')
-const postInstall = require('./post-install')
+const preInstall = require("./pre-install");
+const postInstall = require("./post-install");
+const configureStyles = require("./configure-styles");
 
 if (require.main === module) {
   setup();
@@ -13,4 +14,5 @@ if (require.main === module) {
 function setup() {
   preInstall();
   postInstall();
+  configureStyles();
 }

--- a/template/scripts/setup/setup.js
+++ b/template/scripts/setup/setup.js
@@ -2,6 +2,7 @@
 const preInstall = require("./pre-install");
 const postInstall = require("./post-install");
 const configureStyles = require("./configure-styles");
+const logger = require("rear-logger")("setup");
 
 if (require.main === module) {
   setup();
@@ -12,7 +13,18 @@ if (require.main === module) {
 ///////////////////////////////////////////
 
 function setup() {
+  logger.log("Setting up your project... \n");
+  logger.info("Removing %cnode_modules/@", "cyan");
   preInstall();
-  postInstall();
-  configureStyles();
+  
+  logger.info("Configuring styles...");
+  configureStyles().then(() => {
+    logger.info(
+      "Symlinking %csrc%c to %cnode_modules/@\n",
+      "green",
+      "reset",
+      "cyan"
+    );
+    postInstall();
+  });
 }


### PR DESCRIPTION
#### :rocket: Enhancement

* Add `--light` command option to `create-component` to create components with
no inner implementation.
* Add `--light` command option to `create-container` to create containers with
no action providers.
* Add support for configuring Sass or CSS stylesheet format.